### PR TITLE
Revert "Build freeglut with GLVND"

### DIFF
--- a/io.github.arunsivaramanneo.GPUViewer.yml
+++ b/io.github.arunsivaramanneo.GPUViewer.yml
@@ -82,12 +82,10 @@ modules:
           - shared-modules/glu/glu-9.0.0.json
 
           - name: freeglut
-            build-options:
-              ldflags: -lGL
             buildsystem: cmake-ninja
             config-opts:
               - -DCMAKE_INSTALL_LIBDIR=/app/lib
-              - -DOpenGL_GL_PREFERENCE=GLVND
+              - -DOpenGL_GL_PREFERENCE=LEGACY
             sources:
               - type: archive
                 url: "https://datapacket.dl.sourceforge.net/project/freeglut/freeglut/3.0.0/freeglut-3.0.0.tar.gz"
@@ -112,7 +110,6 @@ modules:
                 dest-filename: autogen.sh
                 commands:
                   - autoreconf -fiv
-
           - name: opencl-headers
             buildsystem: simple
             build-commands:


### PR DESCRIPTION
Freeglut fails to build with GLVND option set explictly.