### PR TITLE
Add f-e-d-c and bump runtime to 21.08

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "automerge-flathubbot-prs": false
+}

--- a/io.github.arunsivaramanneo.GPUViewer.appdata.xml
+++ b/io.github.arunsivaramanneo.GPUViewer.appdata.xml
@@ -28,9 +28,9 @@
             <image>https://user-images.githubusercontent.com/30646692/42731016-18ca0628-8822-11e8-90c1-def21ee5d0bb.png</image>
         </screenshot>
     </screenshots>
-    <content_rating type="oars-1.1" />
+    <content_rating type="oars-1.1"/>
     <releases>
-        <release version="1.35" date="2021-09-26" />
-        <release version="1.15" date="2018-12-22" />
+        <release version="1.35" date="2021-09-27"/>
+        <release version="1.15" date="2018-12-22"/>
     </releases>
 </component>

--- a/io.github.arunsivaramanneo.GPUViewer.yml
+++ b/io.github.arunsivaramanneo.GPUViewer.yml
@@ -1,7 +1,7 @@
 id: io.github.arunsivaramanneo.GPUViewer
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: '20.08'
+runtime-version: '21.08'
 finish-args:
   - --device=dri
   - --share=ipc
@@ -71,20 +71,6 @@ modules:
               stable-only: true
               url-template: https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-$version/Vulkan-Tools-sdk-$version.tar.gz
         modules:
-          - name: glslang
-            buildsystem: cmake-ninja
-            config-opts:
-              - -DBUILD_SHARED_LIBS=ON
-            sources:
-              - type: archive
-                url: https://github.com/KhronosGroup/glslang/archive/11.6.0/glslang-11.6.0.tar.gz
-                sha256: 99ecd3a0c2c2219293d76723846f762a9f3e7dd0dc2a4f346d0fc3a05a0ce000
-                x-checker-data:
-                  type: anitya
-                  project-id: 205796
-                  stable-only: true
-                  url-template: https://github.com/KhronosGroup/glslang/archive/$version/glslang-$version.tar.gz
-
           - name: vulkan-headers
             buildsystem: cmake-ninja
             sources:

--- a/io.github.arunsivaramanneo.GPUViewer.yml
+++ b/io.github.arunsivaramanneo.GPUViewer.yml
@@ -41,6 +41,12 @@ modules:
       - type: archive
         url: "https://github.com/arunsivaramanneo/GPU-Viewer/archive/v1.35.tar.gz"
         sha256: dadcd5834855adbc728ed1ef28e009f05b6d9224b0902576356bd503a63b00d4
+        x-checker-data:
+          is-main-source: true
+          type: anitya
+          project-id: 235097
+          stable-only: true
+          url-template: "https://github.com/arunsivaramanneo/GPU-Viewer/archive/v$version/GPU-Viewer-$version.tar.gz"
       - type: script
         dest-filename: gpu-viewer.sh
         commands:
@@ -60,6 +66,11 @@ modules:
           - type: archive
             url: "https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-1.2.170.0.tar.gz"
             sha256: 0408ab3d2020e2e3a622be0dcac8d223cafe9a1123b4dff67a0ecc4e758718b4
+            x-checker-data:
+              type: anitya
+              project-id: 15953
+              stable-only: true
+              url-template: "https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-$version/Vulkan-Tools-sdk-$version.tar.gz"
         modules:
           - name: glslang
             buildsystem: cmake-ninja
@@ -69,6 +80,11 @@ modules:
               - type: archive
                 url: "https://github.com/KhronosGroup/glslang/archive/11.2.0.tar.gz"
                 sha256: 8ff2fcf9b054e4a4ef56fcd8a637322f827b2b176a592a618d63672ddb896e06
+                x-checker-data:
+                  type: anitya
+                  project-id: 205796
+                  stable-only: true
+                  url-template: "https://github.com/KhronosGroup/glslang/archive/$version/glslang-$version.tar.gz"
 
           - name: vulkan-headers
             buildsystem: cmake-ninja
@@ -76,6 +92,11 @@ modules:
               - type: archive
                 url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.2.170.0.tar.gz"
                 sha256: d8e6050230ca678bcb0e7dc68d5984290da6eb655e8da9d08b5eaab1e84a7da9
+                x-checker-data:
+                  type: anitya
+                  project-id: 88835
+                  stable-only: true
+                  url-template: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v$version/Vulkan-Headers-v$version.tar.gz"
 
       - name: mesa-demos
         config-opts:
@@ -87,6 +108,11 @@ modules:
           - type: archive
             url: "https://mesa.freedesktop.org/archive/demos/mesa-demos-8.4.0.tar.bz2"
             sha256: 01e99c94a0184e63e796728af89bfac559795fb2a0d6f506fa900455ca5fff7d
+            x-checker-data:
+              type: anitya
+              project-id: 16781
+              stable-only: true
+              url-template: "https://mesa.freedesktop.org/archive/demos/mesa-demos-$version.tar.bz2"
         cleanup:
           - /lib/mesa-demos
         modules:
@@ -105,6 +131,11 @@ modules:
               - type: archive
                 url: "https://downloads.sourceforge.net/freeglut/freeglut-3.2.1.tar.gz"
                 sha256: d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68
+                x-checker-data:
+                  type: anitya
+                  project-id: 846
+                  stable-only: true
+                  url-template: "https://downloads.sourceforge.net/freeglut/freeglut-$version.tar.gz"
 
       - name: clinfo
         no-autogen: true
@@ -115,6 +146,11 @@ modules:
           - type: archive
             url: "https://github.com/Oblomov/clinfo/archive/3.0.21.02.21.tar.gz"
             sha256: e52f5c374a10364999d57a1be30219b47fb0b4f090e418f2ca19a0c037c1e694
+            x-checker-data:
+              type: anitya
+              project-id: 10503
+              stable-only: true
+              url-template: "https://github.com/Oblomov/clinfo/archive/$version/clinfo-$version.tar.gz"
         modules:
           - name: opencl-headers
             buildsystem: cmake
@@ -124,6 +160,11 @@ modules:
               - type: archive
                 url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.12.18.tar.gz"
                 sha256: 5dad6d436c0d7646ef62a39ef6cd1f3eba0a98fc9157808dfc1d808f3705ebc2
+                x-checker-data:
+                  type: anitya
+                  project-id: 223257
+                  stable-only: true
+                  url-template: "https://github.com/KhronosGroup/OpenCL-Headers/archive/v$version/OpenCL-Headers-v$version.tar.gz"
 
       - name: pygobject
         buildsystem: meson
@@ -131,6 +172,11 @@ modules:
           - type: archive
             url: "https://gitlab.gnome.org/GNOME/pygobject/-/archive/3.40.1/pygobject-3.40.1.tar.gz"
             sha256: 3cd4a350ee997978de3c7d73d008788eeb4149816395016f269bbfa51a01b69b
+            x-checker-data:
+              type: anitya
+              project-id: 13158
+              stable-only: true
+              url-template: "https://gitlab.gnome.org/GNOME/pygobject/-/archive/$version/pygobject-$version.tar.gz"
         modules:
           - name: pycairo
             buildsystem: meson
@@ -138,12 +184,22 @@ modules:
               - type: archive
                 url: "https://github.com/pygobject/pycairo/archive/refs/tags/v1.20.0.tar.gz"
                 sha256: b5ee5318ad10e6f0b5aeedd4ff4b66b341b8fb1a348076812d0f7751f7691ddf
+                x-checker-data:
+                  type: anitya
+                  project-id: 13166
+                  stable-only: true
+                  url-template: "https://github.com/pygobject/pycairo/archive/v$version/pycairo-v$version.tar.gz"
 
       - name: vdpauinfo
         sources:
           - type: archive
             url: "https://gitlab.freedesktop.org/vdpau/vdpauinfo/-/archive/1.4/vdpauinfo-1.4.tar.gz"
             sha256: 52377604a4f27afdee67c85b62b66457a981747009c839953d3fba5c4c89cb66
+            x-checker-data:
+              type: anitya
+              project-id: 16031
+              stable-only: true
+              url-template: "https://gitlab.freedesktop.org/vdpau/vdpauinfo/-/archive/$version/vdpauinfo-$version.tar.gz"
 
       - name: lsb-release-compat
         buildsystem: simple
@@ -152,4 +208,5 @@ modules:
         sources:
           - type: git
             url: "https://gitlab.com/nanonyme/lsb-release-compat.git"
+            branch: master
             commit: f4f908b62dcc9cd081eb2a42b6ad7cf98db4bb10

--- a/io.github.arunsivaramanneo.GPUViewer.yml
+++ b/io.github.arunsivaramanneo.GPUViewer.yml
@@ -1,7 +1,7 @@
 id: io.github.arunsivaramanneo.GPUViewer
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: "20.08"
+runtime-version: '20.08'
 finish-args:
   - --device=dri
   - --share=ipc
@@ -9,8 +9,8 @@ finish-args:
   - --socket=wayland
 command: gpu-viewer
 cleanup:
-  - "*.a"
-  - "*.la"
+  - '*.a'
+  - '*.la'
   - /include
   - /lib/cmake
   - /lib/pkgconfig
@@ -22,10 +22,9 @@ modules:
       - rm -r Files/__pycache__
       # Install project
       - install -dm755 /app/share/gpu-viewer
-      - cp -r --preserve=mode -t /app/share/gpu-viewer/
-          Files Images
-      - install -Dm644 -t /app/share/gpu-viewer/
-          "About GPU Viewer" "Change Log.md" LICENSE README.md
+      - cp -r --preserve=mode -t /app/share/gpu-viewer/ Files Images
+      - install -Dm644 -t /app/share/gpu-viewer/ "About GPU Viewer" "Change Log.md"
+        LICENSE README.md
       - install -Dm755 gpu-viewer.sh /app/bin/gpu-viewer
       - install -Dm644 Images/GPU_Viewer.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
       - install -Dm644 gpu-viewer.desktop /app/share/applications/${FLATPAK_ID}.desktop
@@ -39,14 +38,14 @@ modules:
       - install -Dm644 -t /app/share/appdata ${FLATPAK_ID}.appdata.xml
     sources:
       - type: archive
-        url: "https://github.com/arunsivaramanneo/GPU-Viewer/archive/v1.35.tar.gz"
+        url: https://github.com/arunsivaramanneo/GPU-Viewer/archive/v1.35/GPU-Viewer-1.35.tar.gz
         sha256: dadcd5834855adbc728ed1ef28e009f05b6d9224b0902576356bd503a63b00d4
         x-checker-data:
           is-main-source: true
           type: anitya
           project-id: 235097
           stable-only: true
-          url-template: "https://github.com/arunsivaramanneo/GPU-Viewer/archive/v$version/GPU-Viewer-$version.tar.gz"
+          url-template: https://github.com/arunsivaramanneo/GPU-Viewer/archive/v$version/GPU-Viewer-$version.tar.gz
       - type: script
         dest-filename: gpu-viewer.sh
         commands:
@@ -64,13 +63,13 @@ modules:
           - -DCMAKE_BUILD_TYPE=Release
         sources:
           - type: archive
-            url: "https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-1.2.170.0.tar.gz"
-            sha256: 0408ab3d2020e2e3a622be0dcac8d223cafe9a1123b4dff67a0ecc4e758718b4
+            url: https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-1.2.189.1/Vulkan-Tools-sdk-1.2.189.1.tar.gz
+            sha256: ef5db0934ff7192657bbfc675f6e3e1ee009f2ad34aab915d2bd9993a59add81
             x-checker-data:
               type: anitya
               project-id: 15953
               stable-only: true
-              url-template: "https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-$version/Vulkan-Tools-sdk-$version.tar.gz"
+              url-template: https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-$version/Vulkan-Tools-sdk-$version.tar.gz
         modules:
           - name: glslang
             buildsystem: cmake-ninja
@@ -78,25 +77,25 @@ modules:
               - -DBUILD_SHARED_LIBS=ON
             sources:
               - type: archive
-                url: "https://github.com/KhronosGroup/glslang/archive/11.2.0.tar.gz"
-                sha256: 8ff2fcf9b054e4a4ef56fcd8a637322f827b2b176a592a618d63672ddb896e06
+                url: https://github.com/KhronosGroup/glslang/archive/11.6.0/glslang-11.6.0.tar.gz
+                sha256: 99ecd3a0c2c2219293d76723846f762a9f3e7dd0dc2a4f346d0fc3a05a0ce000
                 x-checker-data:
                   type: anitya
                   project-id: 205796
                   stable-only: true
-                  url-template: "https://github.com/KhronosGroup/glslang/archive/$version/glslang-$version.tar.gz"
+                  url-template: https://github.com/KhronosGroup/glslang/archive/$version/glslang-$version.tar.gz
 
           - name: vulkan-headers
             buildsystem: cmake-ninja
             sources:
               - type: archive
-                url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.2.170.0.tar.gz"
-                sha256: d8e6050230ca678bcb0e7dc68d5984290da6eb655e8da9d08b5eaab1e84a7da9
+                url: https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.193/Vulkan-Headers-v1.2.193.tar.gz
+                sha256: 52e039b91a27fa2a9e9fa8e39803df1b57cf803c27b67f67d74ba5eacdaf864e
                 x-checker-data:
                   type: anitya
                   project-id: 88835
                   stable-only: true
-                  url-template: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v$version/Vulkan-Headers-v$version.tar.gz"
+                  url-template: https://github.com/KhronosGroup/Vulkan-Headers/archive/v$version/Vulkan-Headers-v$version.tar.gz
 
       - name: mesa-demos
         config-opts:
@@ -106,13 +105,13 @@ modules:
           - mv -v /app/lib/mesa-demos/*info /app/bin/
         sources:
           - type: archive
-            url: "https://mesa.freedesktop.org/archive/demos/mesa-demos-8.4.0.tar.bz2"
+            url: https://mesa.freedesktop.org/archive/demos/mesa-demos-8.4.0.tar.bz2
             sha256: 01e99c94a0184e63e796728af89bfac559795fb2a0d6f506fa900455ca5fff7d
             x-checker-data:
               type: anitya
               project-id: 16781
               stable-only: true
-              url-template: "https://mesa.freedesktop.org/archive/demos/mesa-demos-$version.tar.bz2"
+              url-template: https://mesa.freedesktop.org/archive/demos/mesa-demos-$version.tar.bz2
         cleanup:
           - /lib/mesa-demos
         modules:
@@ -129,13 +128,13 @@ modules:
               - -DOpenGL_GL_PREFERENCE=LEGACY
             sources:
               - type: archive
-                url: "https://downloads.sourceforge.net/freeglut/freeglut-3.2.1.tar.gz"
+                url: https://downloads.sourceforge.net/freeglut/freeglut-3.2.1.tar.gz
                 sha256: d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68
                 x-checker-data:
                   type: anitya
                   project-id: 846
                   stable-only: true
-                  url-template: "https://downloads.sourceforge.net/freeglut/freeglut-$version.tar.gz"
+                  url-template: https://downloads.sourceforge.net/freeglut/freeglut-$version.tar.gz
 
       - name: clinfo
         no-autogen: true
@@ -144,13 +143,13 @@ modules:
           - install -Dm755 -t /app/bin/ clinfo
         sources:
           - type: archive
-            url: "https://github.com/Oblomov/clinfo/archive/3.0.21.02.21.tar.gz"
+            url: https://github.com/Oblomov/clinfo/archive/3.0.21.02.21/clinfo-3.0.21.02.21.tar.gz
             sha256: e52f5c374a10364999d57a1be30219b47fb0b4f090e418f2ca19a0c037c1e694
             x-checker-data:
               type: anitya
               project-id: 10503
               stable-only: true
-              url-template: "https://github.com/Oblomov/clinfo/archive/$version/clinfo-$version.tar.gz"
+              url-template: https://github.com/Oblomov/clinfo/archive/$version/clinfo-$version.tar.gz
         modules:
           - name: opencl-headers
             buildsystem: cmake
@@ -158,48 +157,48 @@ modules:
               - -DCMAKE_INSTALL_DATADIR=/app/lib
             sources:
               - type: archive
-                url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.12.18.tar.gz"
-                sha256: 5dad6d436c0d7646ef62a39ef6cd1f3eba0a98fc9157808dfc1d808f3705ebc2
+                url: https://github.com/KhronosGroup/OpenCL-Headers/archive/v2021.06.30/OpenCL-Headers-v2021.06.30.tar.gz
+                sha256: 6640d590c30d90f89351f5e3043ae6363feeb19ac5e64bc35f8cfa1a6cd5498e
                 x-checker-data:
                   type: anitya
                   project-id: 223257
                   stable-only: true
-                  url-template: "https://github.com/KhronosGroup/OpenCL-Headers/archive/v$version/OpenCL-Headers-v$version.tar.gz"
+                  url-template: https://github.com/KhronosGroup/OpenCL-Headers/archive/v$version/OpenCL-Headers-v$version.tar.gz
 
       - name: pygobject
         buildsystem: meson
         sources:
           - type: archive
-            url: "https://gitlab.gnome.org/GNOME/pygobject/-/archive/3.40.1/pygobject-3.40.1.tar.gz"
-            sha256: 3cd4a350ee997978de3c7d73d008788eeb4149816395016f269bbfa51a01b69b
+            url: https://gitlab.gnome.org/GNOME/pygobject/-/archive/3.42.0/pygobject-3.42.0.tar.gz
+            sha256: b4d40fcd6b61a918eb33a44c5cc59bfb1b32169c593948cc0d013712b4ff579e
             x-checker-data:
               type: anitya
               project-id: 13158
               stable-only: true
-              url-template: "https://gitlab.gnome.org/GNOME/pygobject/-/archive/$version/pygobject-$version.tar.gz"
+              url-template: https://gitlab.gnome.org/GNOME/pygobject/-/archive/$version/pygobject-$version.tar.gz
         modules:
           - name: pycairo
             buildsystem: meson
             sources:
               - type: archive
-                url: "https://github.com/pygobject/pycairo/archive/refs/tags/v1.20.0.tar.gz"
-                sha256: b5ee5318ad10e6f0b5aeedd4ff4b66b341b8fb1a348076812d0f7751f7691ddf
+                url: https://github.com/pygobject/pycairo/archive/v1.20.1/pycairo-v1.20.1.tar.gz
+                sha256: 34f0a86ee5d98f3fca1f09dd3960d43ea9937b2df44f5270d2eb94f529677150
                 x-checker-data:
                   type: anitya
                   project-id: 13166
                   stable-only: true
-                  url-template: "https://github.com/pygobject/pycairo/archive/v$version/pycairo-v$version.tar.gz"
+                  url-template: https://github.com/pygobject/pycairo/archive/v$version/pycairo-v$version.tar.gz
 
       - name: vdpauinfo
         sources:
           - type: archive
-            url: "https://gitlab.freedesktop.org/vdpau/vdpauinfo/-/archive/1.4/vdpauinfo-1.4.tar.gz"
+            url: https://gitlab.freedesktop.org/vdpau/vdpauinfo/-/archive/1.4/vdpauinfo-1.4.tar.gz
             sha256: 52377604a4f27afdee67c85b62b66457a981747009c839953d3fba5c4c89cb66
             x-checker-data:
               type: anitya
               project-id: 16031
               stable-only: true
-              url-template: "https://gitlab.freedesktop.org/vdpau/vdpauinfo/-/archive/$version/vdpauinfo-$version.tar.gz"
+              url-template: https://gitlab.freedesktop.org/vdpau/vdpauinfo/-/archive/$version/vdpauinfo-$version.tar.gz
 
       - name: lsb-release-compat
         buildsystem: simple
@@ -207,6 +206,6 @@ modules:
           - make install PREFIX=/app
         sources:
           - type: git
-            url: "https://gitlab.com/nanonyme/lsb-release-compat.git"
+            url: https://gitlab.com/nanonyme/lsb-release-compat.git
             branch: master
             commit: f4f908b62dcc9cd081eb2a42b6ad7cf98db4bb10

--- a/io.github.arunsivaramanneo.GPUViewer.yml
+++ b/io.github.arunsivaramanneo.GPUViewer.yml
@@ -63,25 +63,8 @@ modules:
           - -DCMAKE_BUILD_TYPE=Release
         sources:
           - type: archive
-            url: https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-1.2.189.1/Vulkan-Tools-sdk-1.2.189.1.tar.gz
-            sha256: ef5db0934ff7192657bbfc675f6e3e1ee009f2ad34aab915d2bd9993a59add81
-            x-checker-data:
-              type: anitya
-              project-id: 15953
-              stable-only: true
-              url-template: https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-$version/Vulkan-Tools-sdk-$version.tar.gz
-        modules:
-          - name: vulkan-headers
-            buildsystem: cmake-ninja
-            sources:
-              - type: archive
-                url: https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.193/Vulkan-Headers-v1.2.193.tar.gz
-                sha256: 52e039b91a27fa2a9e9fa8e39803df1b57cf803c27b67f67d74ba5eacdaf864e
-                x-checker-data:
-                  type: anitya
-                  project-id: 88835
-                  stable-only: true
-                  url-template: https://github.com/KhronosGroup/Vulkan-Headers/archive/v$version/Vulkan-Headers-v$version.tar.gz
+            url: https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-1.2.182.0/Vulkan-Tools-sdk-1.2.182.0.tar.gz
+            sha256: 584817d57169604f9d568835f907923e7a84dcc014aa19fe44c54fb22b8fb6a4
 
       - name: mesa-demos
         config-opts:


### PR DESCRIPTION
* Update shared-modules.
* Add f-e-d-c support.
* Run f-e-d-c manually to update the app's dependencies.
* Bump runtime to 21.08, and drop glslang module.
* Remove vulkan-headers module, and sync vulkan-tools with the headers from the runtime.

Extra notes about f-e-d-c:

* Misc cosmetic changes were made by f-e-d-c.
* Auto merging was disabled, part of this because the app does not make use of a build system, but as I feel this a decision for the maintainer.
* Github's API has a rate limit of 60 unauthenticated requests per hour. I'm not sure about flathubbot, but the rate limit is an annoyance when working locally, so I avoided the JSON checker and chose to use the Anitya checker.  
~~* I haven't touched the source URL quoting, and kept it for the f-e-d-c URL templates, though I believe it's unnecessary.~~ f-e-d-c removed the quoting automaitcally.