### PR TITLE
Update to 1.37

### DIFF
--- a/io.github.arunsivaramanneo.GPUViewer.appdata.xml
+++ b/io.github.arunsivaramanneo.GPUViewer.appdata.xml
@@ -30,6 +30,7 @@
     </screenshots>
     <content_rating type="oars-1.1"/>
     <releases>
+        <release version="1.37" date="2021-12-06"/>
         <release version="1.36" date="2021-10-15"/>
         <release version="1.35" date="2021-09-27"/>
         <release version="1.15" date="2018-12-22"/>

--- a/io.github.arunsivaramanneo.GPUViewer.yml
+++ b/io.github.arunsivaramanneo.GPUViewer.yml
@@ -25,6 +25,9 @@ modules:
       - install -Dm755 gpu-viewer.sh /app/bin/gpu-viewer
       - install -Dm644 Images/GPU_Viewer.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
       - install -Dm644 gpu-viewer.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      # desktop-file-utils validator doesn't support v1.5, see CURRENT_SPEC_VERSION @src/validate.h
+      #  and https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/issues/59
+      - desktop-file-edit --set-key=Version --set-value=1.4 /app/share/applications/${FLATPAK_ID}.desktop
       - desktop-file-edit --set-key=Icon --set-value=${FLATPAK_ID} /app/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 -t /app/share/appdata ${FLATPAK_ID}.appdata.xml
     sources:

--- a/io.github.arunsivaramanneo.GPUViewer.yml
+++ b/io.github.arunsivaramanneo.GPUViewer.yml
@@ -29,8 +29,8 @@ modules:
       - install -Dm644 -t /app/share/appdata ${FLATPAK_ID}.appdata.xml
     sources:
       - type: archive
-        url: https://github.com/arunsivaramanneo/GPU-Viewer/archive/c898afce82f28f13885b24e895ce183112c0bf44.tar.gz
-        sha256: 11420bc387e8a01541a62860f96906f04798c952bc8240177475cf0c897c86df
+        url: https://github.com/arunsivaramanneo/GPU-Viewer/archive/v1.37/GPU-Viewer-1.37.tar.gz
+        sha256: 8cb0d85b342f645e6df2c6c442ac6c5f0925bd73dde38da470b96b2890be046e
         x-checker-data:
           is-main-source: true
           type: anitya


### PR DESCRIPTION
The automated flathubbot PR is failing as the desktop file validator of desktop-file-utils doesn't support v1.5, so a workaround was added. See https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/issues/59