### PR TITLE
Update runtime to Freedesktop 22.08

### DIFF
--- a/io.github.arunsivaramanneo.GPUViewer.yml
+++ b/io.github.arunsivaramanneo.GPUViewer.yml
@@ -44,8 +44,8 @@ modules:
           - -DCMAKE_BUILD_TYPE=Release
         sources:
           - type: archive
-            url: https://github.com/KhronosGroup/Vulkan-Tools/archive/v1.3.219/Vulkan-Tools-1.3.219.tar.gz
-            sha256: 33d67be600615dd91b5f07aa5a5e1a2cf73ee9a54f50844cebd44566ea6e4e22
+            url: https://github.com/KhronosGroup/Vulkan-Tools/archive/v1.3.225/Vulkan-Tools-1.3.225.tar.gz
+            sha256: f30dfedb2a5630b981ee93627f4ec6be9cef95d6b8527340437207276bd0d18e
             x-checker-data:
               type: anitya
               project-id: 242111
@@ -56,8 +56,8 @@ modules:
             buildsystem: cmake-ninja
             sources:
               - type: archive
-                url: https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.3.219/Vulkan-Headers-v1.3.219.tar.gz
-                sha256: 3e5d1b727a5e3a5546e6b0709d520d3f522f0a83808277a313357140645be90c
+                url: https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.3.225/Vulkan-Headers-v1.3.225.tar.gz
+                sha256: 71bfa18ef3df0c39b1dc194727166e4ec1c51df7254ac86e0b9c27fd10cf85ad
                 x-checker-data:
                   type: anitya
                   project-id: 88835
@@ -137,8 +137,8 @@ modules:
         buildsystem: meson
         sources:
           - type: archive
-            url: https://gitlab.gnome.org/GNOME/pygobject/-/archive/3.42.1/pygobject-3.42.1.tar.gz
-            sha256: 53fff1eef7f94533f18164c2df2fcc16cd447aac71f34efc8a735a21bc3bebd5
+            url: https://gitlab.gnome.org/GNOME/pygobject/-/archive/3.42.2/pygobject-3.42.2.tar.gz
+            sha256: 56e6833f875bfe55409c780b9c87a9fc426c1cd55b3c65836de9d384d206201f
             x-checker-data:
               type: anitya
               project-id: 13158
@@ -173,8 +173,8 @@ modules:
       - name: vdpauinfo
         sources:
           - type: archive
-            url: https://gitlab.freedesktop.org/vdpau/vdpauinfo/-/archive/1.4/vdpauinfo-1.4.tar.gz
-            sha256: 52377604a4f27afdee67c85b62b66457a981747009c839953d3fba5c4c89cb66
+            url: https://gitlab.freedesktop.org/vdpau/vdpauinfo/-/archive/1.5/vdpauinfo-1.5.tar.gz
+            sha256: 1878d54f6732d02cedef8eabe77e23fc2239b4ec202612403a383f4140a17bc3
             x-checker-data:
               type: anitya
               project-id: 16031

--- a/io.github.arunsivaramanneo.GPUViewer.yml
+++ b/io.github.arunsivaramanneo.GPUViewer.yml
@@ -1,7 +1,7 @@
 id: io.github.arunsivaramanneo.GPUViewer
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '22.08'
 finish-args:
   - --device=dri
   - --share=ipc


### PR DESCRIPTION
- Update shared-module to latest commit in master
- Update runtime to Freedesktop 22.08
- Update 4 modules
  - vulkan tools and headers 1.3.225
  - pygobject 3.42.2
  - vdpauinfo 1.5